### PR TITLE
Implement Phase Offset

### DIFF
--- a/src/libnorad/cOrbitA.cc
+++ b/src/libnorad/cOrbitA.cc
@@ -44,7 +44,7 @@ cOrbitA::cOrbitA(std::string satNameA, int epochY, double epochD, double altitud
 
    raan = 360.0 / planes * currentPlane * RADS_PER_DEG; //RAAN value, uniformly created so that there are equally spaced orbital planes for even coverage.
 
-   meanAnomaly = (360.0 / satPerPlane * planeIndex + phaseOffsetVal) * RADS_PER_DEG;
+   meanAnomaly = (360.0 / satPerPlane * planeIndex + phaseOffsetVal) * RADS_PER_DEG; //Denotes the position of a satellite within its plane.
 
    m_jdEpoch = cJulian(epochYear, epochDay);
 

--- a/src/libnorad/cOrbitA.cc
+++ b/src/libnorad/cOrbitA.cc
@@ -36,11 +36,13 @@ cOrbitA::cOrbitA(std::string satNameA, int epochY, double epochD, double altitud
    bstar = bstarA;
    drag = dragA;
    //int offsetVal = planes; //offsetVal must be changed according to constellation, used to prevent collisions
-   int currentPlane = trunc(satIndex/satPerPlane);
-   int planeIndex = (satIndex % (planes*satPerPlane))-(satPerPlane*currentPlane); //index of a satellite within a plane
-   raan = ((360.0/planes)*currentPlane) * RADS_PER_DEG; //RAAN value, uniformly created so that there are equally spaced orbital planes for even coverage.
-   double phaseOffsetVal = ((360.0 / satPerPlane) * (static_cast<double>(phaseOffset) / planes)) * currentPlane;
-   meanAnomaly = (((360.0/satPerPlane)*planeIndex))*RADS_PER_DEG; //Denotes the position of a satellite within its plane.
+   const int currentPlane = satIndex / satPerPlane;
+   const int planeIndex = satIndex % satPerPlane; //index of a satellite within a plane
+
+   raan = 360.0 / planes * currentPlane * RADS_PER_DEG; //RAAN value, uniformly created so that there are equally spaced orbital planes for even coverage.
+
+   const double phaseOffsetVal = 360.0 / satPerPlane * (static_cast<double>(phaseOffset) / static_cast<double>(planes)) * currentPlane;
+   meanAnomaly = (360.0 / satPerPlane * planeIndex + phaseOffsetVal) * RADS_PER_DEG;
 
    m_jdEpoch = cJulian(epochYear, epochDay);
 

--- a/src/libnorad/cOrbitA.cc
+++ b/src/libnorad/cOrbitA.cc
@@ -36,12 +36,14 @@ cOrbitA::cOrbitA(std::string satNameA, int epochY, double epochD, double altitud
    bstar = bstarA;
    drag = dragA;
    //int offsetVal = planes; //offsetVal must be changed according to constellation, used to prevent collisions
+   const int satelliteCount = satPerPlane * planes;
    const int currentPlane = satIndex / satPerPlane;
    const int planeIndex = satIndex % satPerPlane; //index of a satellite within a plane
 
+   const double phaseOffsetVal = static_cast<double>(currentPlane * phaseOffset * 360) / static_cast<double>(satelliteCount);
+
    raan = 360.0 / planes * currentPlane * RADS_PER_DEG; //RAAN value, uniformly created so that there are equally spaced orbital planes for even coverage.
 
-   const double phaseOffsetVal = 360.0 / satPerPlane * (static_cast<double>(phaseOffset) / static_cast<double>(planes)) * currentPlane;
    meanAnomaly = (360.0 / satPerPlane * planeIndex + phaseOffsetVal) * RADS_PER_DEG;
 
    m_jdEpoch = cJulian(epochYear, epochDay);


### PR DESCRIPTION
This is my proposed implementation for a phase offset. Closes #32. 

A Walker delta constellation is defined as $i = t / p / f$, where
- `i`: inclination.
- `t`: total number of satellites.
- `p`: number of orbital planes.
- `f`: phase offset.

The offset per plane is therefore calculated as $f · 360 / t$. Considering the offset needs to accumulate as the orbit index changes (an offset of 15º between orbits $i$ and $i+1$ means that there should be an offset of 30º between orbits $i$ and $i+2$), we get:

$$offset = planeIdx · f · \frac{360}{t}$$

Rewriting this into the parameters available to cOrbitA, we get:

$$offset = currentPlane · f · \frac{360}{p · satPerPlane}$$

Changes to existing variables are included to improve code quality and simplify existing formulas.

Same constellation, at the same exact time as the one showcased in #32, with a phase offset of 7: 

<img width="2503" height="1254" alt="phase7" src="https://github.com/user-attachments/assets/3fce99d7-b4a9-4194-889a-d6d39d0bad3a" />


